### PR TITLE
TEMP: disable CSS until core is updated

### DIFF
--- a/about.json
+++ b/about.json
@@ -1,8 +1,6 @@
 {
   "about_url": null,
   "license_url": null,
-  "assets": {
-  },
   "name": "Category Badge Styles",
   "component": true
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,3 +1,5 @@
+/* All CSS is intentionally commented out until the relevant core update is made
+
 .badge-wrapper {
   --badge-category-padding-v: 0.15em;
   --badge-category-padding-h: 0.33em;
@@ -8,7 +10,7 @@
     }
   }
 
-  @if $category-badge-style == 'box' {
+  @if $category-badge-style == "box" {
     .badge-category {
       background: var(--category-badge-color);
       padding: var(--badge-category-padding-v) var(--badge-category-padding-h);
@@ -19,24 +21,24 @@
       .d-icon {
         color: currentColor;
       }
+    }
 
-      &.badge-subcategory {
-        padding-left: calc(var(--badge-category-padding-h) * 2);
-        &:before {
-          content: '';
-          display: block;
-          width: var(--badge-category-padding-h);
-          height: 100%;
-          position: absolute;
-          left: 0;
-          top: 0;
-          background: var(--parent-category-badge-color);
-        }
+    [class*="badge-subcategory-"] {
+      padding-left: calc(var(--badge-category-padding-h) * 2);
+      &:before {
+        content: "";
+        display: block;
+        width: var(--badge-category-padding-h);
+        height: 100%;
+        position: absolute;
+        left: 0;
+        top: 0;
+        background: var(--parent-category-badge-color);
       }
     }
   }
 
-  @if $category-badge-style == 'bar' {
+  @if $category-badge-style == "bar" {
     + .badge-wrapper {
       margin-left: calc(var(--badge-category-padding-h) * 2);
     }
@@ -50,25 +52,25 @@
       .d-icon {
         color: var(--primary-medium);
       }
+    }
 
-      &.badge-subcategory {
-        padding-left: calc(var(--badge-category-padding-h) * 2);
-        &:before {
-          content: '';
-          display: block;
-          width: var(--badge-category-padding-h);
-          margin-left: var(--badge-category-padding-h);
-          height: 100%;
-          position: absolute;
-          left: 0;
-          top: 0;
-          background: var(--parent-category-badge-color);
-        }
+    [class*="badge-subcategory-"] {
+      padding-left: calc(var(--badge-category-padding-h) * 2);
+      &:before {
+        content: "";
+        display: block;
+        width: var(--badge-category-padding-h);
+        margin-left: var(--badge-category-padding-h);
+        height: 100%;
+        position: absolute;
+        left: 0;
+        top: 0;
+        background: var(--parent-category-badge-color);
       }
     }
   }
 
-  @if $category-badge-style == 'none' {
+  @if $category-badge-style == "none" {
     &:before {
       display: none;
     }
@@ -77,10 +79,12 @@
 
 // Some special category breadcrumb styles for box
 
-@if $category-badge-style == 'box' {
+@if $category-badge-style == "box" {
   .list-controls .category-breadcrumb .combo-box .combo-box-header {
     background: var(--category-bg-color);
     color: var(--category-text-color);
     border-color: var(--category-bg-color);
   }
 }
+
+*/

--- a/settings.yml
+++ b/settings.yml
@@ -1,6 +1,6 @@
 category_badge_style:
-  type: 'enum'
-  default: 'box'
+  type: "enum"
+  default: "box"
   choices:
     - box
     - bar


### PR DESCRIPTION
This update will rely on Discourse changes, but we want people to be able to install this and choose a setting before the update is made to help make the transition more seamless. 

By commenting out the CSS, we can allow this to be installed and configured without effect. 

Once we have our core update ready, we can update this theme component with a `.discourse-compatibility` file that will enable the CSS to be enabled along with the relevant Discourse version.