### PR TITLE
UX: update category badge variable to match core

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -87,9 +87,9 @@
 
 @if $category-badge-style == "box" {
   .list-controls .category-breadcrumb .combo-box .combo-box-header {
-    background: var(--category-bg-color);
-    color: var(--category-text-color);
-    border-color: var(--category-bg-color);
+    background: var(--category-badge-color);
+    color: var(--category-badge-text-color);
+    border-color: var(--category-badge-color);
     padding-top: 0;
     padding-bottom: 0;
   }


### PR DESCRIPTION
The core variable rename caused the dropdown style to regress a little:

Before:
![Screenshot 2024-01-04 at 11 06 22 AM](https://github.com/discourse/discourse-category-badge-styles/assets/1681963/57f2bc70-b99b-4bfe-b1bd-45daa0a6ceb3)

After:
![Screenshot 2024-01-04 at 11 06 17 AM](https://github.com/discourse/discourse-category-badge-styles/assets/1681963/cedb2694-e51a-4125-b5ba-a23807ab4cbc)
