### PR TITLE
UX: spacing and alignment adjustments for box mode

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -83,7 +83,7 @@
   }
 }
 
-// Some special category breadcrumb styles for box
+// Some special styles for box
 
 @if $category-badge-style == "box" {
   .list-controls .category-breadcrumb .combo-box .combo-box-header {
@@ -92,5 +92,18 @@
     border-color: var(--category-bg-color);
     padding-top: 0;
     padding-bottom: 0;
+  }
+
+  .category-list .subcategories {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25em;
+    .subcategory {
+      margin: 0;
+    }
+  }
+
+  .latest-topic-list-item .main-link .bottom-row {
+    align-items: baseline;
   }
 }


### PR DESCRIPTION
Fixes some minor alignment and spacing issues on /categories 

Before:

![Screenshot 2024-01-05 at 12 32 21 PM](https://github.com/discourse/discourse-category-badge-styles/assets/1681963/0bde3be7-eec8-4822-b1f4-40b430e09a68)

(tag too high)
![Screenshot 2024-01-05 at 12 33 10 PM](https://github.com/discourse/discourse-category-badge-styles/assets/1681963/d184024c-6197-4030-81d7-f2478d3194f8)

After:

![Screenshot 2024-01-05 at 12 32 13 PM](https://github.com/discourse/discourse-category-badge-styles/assets/1681963/1bd4a75b-3701-4948-adca-b93dfde11ee7)

![Screenshot 2024-01-05 at 12 33 00 PM](https://github.com/discourse/discourse-category-badge-styles/assets/1681963/86a2c5f1-faa7-4f1f-9ee4-6e928b46ba54)
