### PR TITLE
UX: tag input height fix for box style

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -86,6 +86,10 @@
 // Some special styles for box
 
 @if $category-badge-style == "box" {
+  #reply-control .category-input + .mini-tag-chooser {
+    align-self: stretch;
+  }
+
   .list-controls .category-breadcrumb .combo-box .combo-box-header {
     background: var(--category-badge-color);
     color: var(--category-badge-text-color);


### PR DESCRIPTION
the box style causes the dropdown height to increase, and this update allows the tag menu height to adjust as needed 

Before:
![Screenshot 2024-01-25 at 3 43 16 PM](https://github.com/discourse/discourse-category-badge-styles/assets/1681963/65a7262c-a52b-46bb-b2ae-a42804a7af17)

After:
![Screenshot 2024-01-25 at 3 43 02 PM](https://github.com/discourse/discourse-category-badge-styles/assets/1681963/a7ca6d04-fe66-41fd-8902-557291ca4abd)
