### PR TITLE
UX: update core override styles

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -49,7 +49,7 @@
     }
 
     // for core and category icons component
-    .--style-icon .d-icon, 
+    .--style-icon .d-icon,
     .badge-category__icon {
       color: var(--category-badge-text-color) !important;
     }
@@ -64,7 +64,7 @@
       }
 
       &.--style-square::before,
-      &.--style-icon::before, 
+      &.--style-icon::before,
       &.--style-emoji::before {
         content: "";
         display: flex;
@@ -90,7 +90,7 @@
     &::before {
       display: none;
     }
-    
+
     .badge-category.--style-icon .d-icon,
     .badge-category.--style-emoji .emoji {
       display: none;

--- a/common/common.scss
+++ b/common/common.scss
@@ -7,7 +7,9 @@
     gap: var(--badge-category-padding-h);
 
     // reset core styles
-    &::before {
+    &.--style-square::before,
+    &.--style-icon::before,
+    &.--style-emoji::before {
       margin-right: 0;
       height: unset;
       display: none;
@@ -31,14 +33,14 @@
       }
     }
 
-    .--has-parent {
+    .--style-square.--has-parent {
       padding-left: calc(var(--badge-category-padding-h) * 2);
 
       &::before {
         content: "";
         display: flex;
         background: var(--parent-category-badge-color);
-        width: calc(var(--badge-category-padding-h) * 2);
+        width: var(--badge-category-padding-h);
         position: absolute;
         left: 0;
         top: 0;
@@ -46,9 +48,10 @@
       }
     }
 
-    // for the category icons component
+    // for core and category icons component
+    .--style-icon .d-icon, 
     .badge-category__icon {
-      color: var(--category-badge-text-color);
+      color: var(--category-badge-text-color) !important;
     }
   }
 
@@ -60,7 +63,9 @@
         color: var(--primary-medium);
       }
 
-      &::before {
+      &.--style-square::before,
+      &.--style-icon::before, 
+      &.--style-emoji::before {
         content: "";
         display: flex;
         width: var(--badge-category-padding-h);
@@ -69,7 +74,7 @@
       }
 
       &.--has-parent {
-        &::before {
+        &.--style-square::before {
           background: linear-gradient(
             90deg,
             var(--parent-category-badge-color) 50%,
@@ -83,6 +88,11 @@
 
   @if $category-badge-style == "none" {
     &::before {
+      display: none;
+    }
+    
+    .badge-category.--style-icon .d-icon,
+    .badge-category.--style-emoji .emoji {
       display: none;
     }
   }


### PR DESCRIPTION
Some styling fixes to allow the theme component to work better since introducing category icons/emojis in core.

### Before

When style is set to `Bar`: 

<img width="386" alt="Screenshot 2025-04-11 at 12 19 33 PM" src="https://github.com/user-attachments/assets/2f424cf6-0f96-4cbc-bf30-b4a445f385ea" />

When style is set to `Box`: 

<img width="336" alt="Screenshot 2025-04-11 at 12 22 38 PM" src="https://github.com/user-attachments/assets/5de0ccec-c4e7-4a11-a436-4763ed760d98" />

_Note that the icon color is hidden due to it also using the category background color. It works in core but is an issue when we have the boxed background color, so we should use the category text color instead._

### After

When style is set to `Bar`: 

<img width="406" alt="Screenshot 2025-04-11 at 12 18 36 PM" src="https://github.com/user-attachments/assets/162444f6-73ec-4856-bb0e-c949d3c2a3a1" />

When using emojis / icons, and square style with parent category:

<img width="328" alt="Screenshot 2025-04-11 at 4 29 25 PM" src="https://github.com/user-attachments/assets/f48a9527-202c-4471-ac6e-6fd7c941c31a" />


When style is set to `Box`: 

<img width="337" alt="Screenshot 2025-04-11 at 3 27 54 PM" src="https://github.com/user-attachments/assets/d5b946a9-39fe-41ee-9c25-0124de63824d" />

When style is set to `Box` and category has a parent:

<img width="170" alt="Screenshot 2025-04-11 at 3 28 58 PM" src="https://github.com/user-attachments/assets/a0c59221-4554-4014-8430-83a8ea44016c" />
