### PR TITLE
FIX: Category badge name color

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -24,12 +24,15 @@
     .badge-category {
       background: var(--category-badge-color);
       padding: var(--badge-category-padding-v) var(--badge-category-padding-h);
-      color: var(
-        --category-badge-text-color
-      ) !important; // overrides specific core styles
 
       .d-icon {
         color: currentcolor;
+      }
+
+      &__name {
+        color: var(
+          --category-badge-text-color
+        ) !important; // overrides specific core styles
       }
     }
 


### PR DESCRIPTION
This PR sets the category badge color on the .badge-category__name to override core styles. Previously the badge wasn't inheriting the correct text color in the topic info header.

## Before
<img width="292" height="51" alt="Screenshot 2026-05-01 at 2 40 02 PM" src="https://github.com/user-attachments/assets/f1e6289c-2675-4cc7-9ad5-1ab617884f89" />


## After
<img width="291" height="53" alt="Screenshot 2026-05-01 at 2 42 23 PM" src="https://github.com/user-attachments/assets/856d1139-8795-4ce9-af88-b1482612d218" />

